### PR TITLE
Add prop to allow output to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ data () {
 }
 ```
 
+### output-format
+
+The format to output from the v-model. This defaults to `html`
+
+For example, to get json instead:
+```vue
+<tiptap-vuetify
+  output-format="json"
+/>
+```
+
 ## Events
 
 ### @init

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -70,6 +70,9 @@ export default class TiptapVuetify extends Vue {
   @Prop({ type: String })
   readonly [PROPS.PLACEHOLDER]: string
 
+  @Prop({ type: String, default: 'html' })
+  readonly [PROPS.OUTPUT_FORMAT]: string
+
   @Prop({
     type: [Array, Object],
     default: () => ({})
@@ -145,7 +148,15 @@ export default class TiptapVuetify extends Vue {
 
   onUpdate (info) {
     this.emitAfterOnUpdate = true
-    this.$emit(EVENTS.INPUT, info.getHTML(), info)
+    let output: any
+
+    if (this[PROPS.OUTPUT_FORMAT] === 'html') {
+      output = info.getHTML()
+    } else {
+      output = JSON.stringify(info.getJSON())
+    }
+
+    this.$emit(EVENTS.INPUT, output, info)
   }
 
   beforeDestroy () {

--- a/src/const.ts
+++ b/src/const.ts
@@ -13,5 +13,6 @@ export const PROPS = {
   TOOLBAR_ATTRIBUTES: 'toolbarAttributes' as const,
   EDITOR_PROPERTIES: 'editorProperties' as const,
   NATIVE_EXTENSIONS: 'nativeExtensions' as const,
-  PLACEHOLDER: 'placeholder' as const
+  PLACEHOLDER: 'placeholder' as const,
+  OUTPUT_FORMAT: 'outputFormat' as const
 }


### PR DESCRIPTION
Added an optional prop `output-format` to the tiptap-vuetify component which lets the user choose if they want html or json outputted. Defaults to html.