### PR TITLE
Added ES (Spanish) translations for text editor buttons' tooltips.

### DIFF
--- a/src/i18n/es/index.ts
+++ b/src/i18n/es/index.ts
@@ -1,0 +1,104 @@
+export default {
+  extensions: {
+    Blockquote: {
+      buttons: {
+        blockquote: {
+          tooltip: 'Cita en bloque'
+        }
+      }
+    },
+    Bold: {
+      buttons: {
+        bold: {
+          tooltip: 'Texto en negrita'
+        }
+      }
+    },
+    BulletList: {
+      buttons: {
+        bulletList: {
+          tooltip: 'Lista no ordenada'
+        }
+      }
+    },
+    Code: {
+      buttons: {
+        code: {
+          tooltip: 'Código'
+        }
+      }
+    },
+    CodeBlock: {
+      buttons: {
+        codeBlock: {
+          tooltip: 'Bloque de código'
+        }
+      }
+    },
+    History: {
+      buttons: {
+        undo: {
+          tooltip: 'Deshacer'
+        },
+        redo: {
+          tooltip: 'Rehacer'
+        }
+      }
+    },
+    HorizontalRule: {
+      buttons: {
+        horizontalRule: {
+          tooltip: 'Línea horizontal'
+        }
+      }
+    },
+    Italic: {
+      buttons: {
+        italic: {
+          tooltip: 'Texto en cursiva'
+        }
+      }
+    },
+    Link: {
+      bubble: {
+        updateLink: 'Actualizar enlace',
+        addLink: 'Añadir enlace'
+      }
+    },
+    OrderedList: {
+      buttons: {
+        orderedList: {
+          tooltip: 'Lista ordenada'
+        }
+      }
+    },
+    Paragraph: {
+      buttons: {
+        paragraph: {
+          tooltip: 'Párrafo'
+        }
+      }
+    },
+    Strike: {
+      buttons: {
+        strike: {
+          tooltip: 'Tachar texto'
+        }
+      }
+    },
+    Underline: {
+      buttons: {
+        underline: {
+          tooltip: 'Subrayar texto'
+        }
+      }
+    },
+    Heading: {
+      buttons: {
+        heading: {
+          tooltip: args => 'Nivel de encabezado ' + args.level
+        }
+      }
+    }
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,13 +1,15 @@
 import Vue from 'vue'
 import en from './en'
 import ru from './ru'
+import es from './es'
 import ConsoleLogger from '~/logging/ConsoleLogger'
 
 export const defaultLanguage = 'en'
 
 export const dictionary = {
   en,
-  ru
+  ru,
+  es
 }
 
 export function getCurrentLang () {


### PR DESCRIPTION
This PR includes Spanish translations for the text editor's button tooltips, just like the English and Russian translations do.
