### PR TITLE
added flat option for the card

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,14 +283,13 @@ For example, to get json instead:
 />
 ```
 
-### flat
+### card-props
 
-This will make remove the card elevation, default="false"
+Allows you to pass props for the editor's `<v-card>`.
 
-For example, to get json instead:
 ```vue
 <tiptap-vuetify
-  flat="true"
+  :card-props="{ flat: true, color: '#26c6da' }"
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ For example, to get json instead:
 />
 ```
 
+### flat
+
+This will make remove the card elevation, default="false"
+
+For example, to get json instead:
+```vue
+<tiptap-vuetify
+  flat="true"
+/>
+```
+
 ## Events
 
 ### @init

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -10,7 +10,10 @@
       :actions="availableActions.bubbleMenu"
     />
 
-    <VCard v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card" v-bind="$props[PROPS.CARD_PROPS]">
+    <VCard
+      v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card"
+      v-bind="$props[PROPS.CARD_PROPS]"
+    >
       <slot name="toolbar-before" />
 
       <toolbar

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -80,7 +80,7 @@ export default class TiptapVuetify extends Vue {
   readonly [PROPS.PLACEHOLDER]: string
 
   @Prop({ type: Object, default: {} })
-  readonly [PROPS.CARD_PROPS]: Object
+  readonly [PROPS.CARD_PROPS]: Record<string, any>
 
   @Prop({ type: String, default: 'html' })
   readonly [PROPS.OUTPUT_FORMAT]: string

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -10,7 +10,7 @@
       :actions="availableActions.bubbleMenu"
     />
 
-    <VCard v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card" :flat="$props[PROPS.FLAT]">
+    <VCard v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card" v-bind="$props[PROPS.CARD_PROPS]">
       <slot name="toolbar-before" />
 
       <toolbar
@@ -76,8 +76,8 @@ export default class TiptapVuetify extends Vue {
   @Prop({ type: String })
   readonly [PROPS.PLACEHOLDER]: string
 
-  @Prop({ type: Boolean, default: false })
-  readonly [PROPS.FLAT]: boolean
+  @Prop({ type: Object, default: {} })
+  readonly [PROPS.CARD_PROPS]: Object
 
   @Prop({ type: String, default: 'html' })
   readonly [PROPS.OUTPUT_FORMAT]: string

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -10,7 +10,7 @@
       :actions="availableActions.bubbleMenu"
     />
 
-    <VCard v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card">
+    <VCard v-if="$props[PROPS.TYPE] === EDITOR_TYPES_ENUM.card" :flat="$props[PROPS.FLAT]">
       <slot name="toolbar-before" />
 
       <toolbar
@@ -75,6 +75,9 @@ export default class TiptapVuetify extends Vue {
 
   @Prop({ type: String })
   readonly [PROPS.PLACEHOLDER]: string
+
+  @Prop({ type: Boolean, default: false })
+  readonly [PROPS.FLAT]: boolean
 
   @Prop({ type: String, default: 'html' })
   readonly [PROPS.OUTPUT_FORMAT]: string

--- a/src/const.ts
+++ b/src/const.ts
@@ -14,7 +14,7 @@ export const PROPS = {
   EDITOR_PROPERTIES: 'editorProperties' as const,
   NATIVE_EXTENSIONS: 'nativeExtensions' as const,
   PLACEHOLDER: 'placeholder' as const,
-  CARD_PROPS: 'card_props' as const,
+  CARD_PROPS: 'cardProps' as const,
   OUTPUT_FORMAT: 'outputFormat' as const,
   TYPE: 'type' as const
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -14,6 +14,7 @@ export const PROPS = {
   EDITOR_PROPERTIES: 'editorProperties' as const,
   NATIVE_EXTENSIONS: 'nativeExtensions' as const,
   PLACEHOLDER: 'placeholder' as const,
+  FLAT: 'flat' as const,
   OUTPUT_FORMAT: 'outputFormat' as const,
   TYPE: 'type' as const
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -14,7 +14,7 @@ export const PROPS = {
   EDITOR_PROPERTIES: 'editorProperties' as const,
   NATIVE_EXTENSIONS: 'nativeExtensions' as const,
   PLACEHOLDER: 'placeholder' as const,
-  FLAT: 'flat' as const,
+  CARD_PROPS: 'card_props' as const,
   OUTPUT_FORMAT: 'outputFormat' as const,
   TYPE: 'type' as const
 }


### PR DESCRIPTION
This PR adds the option to use the flat option of v-card.

Thanks for your work, I was using this library in a dialogue and it looked strange with the elevation. In certain cases, I think it can be more convenient to show the editor inside a flat card.

I am kind of new to Vue, so sorry I miss something.