### PR TITLE
Added min- and maxHeight attributes

### DIFF
--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -36,7 +36,10 @@
 
       <slot name="toolbar-after" />
 
-      <div class="tiptap-vuetify-editor__content">
+      <div
+        class="tiptap-vuetify-editor__content"
+        :style="contentDynamicStyles"
+      >
         <editor-content
           :editor="editor"
         />
@@ -112,6 +115,12 @@ export default class TiptapVuetify extends Vue {
   })
   readonly [PROPS.TYPE]: EDITOR_TYPES_ENUM
 
+  @Prop({ type: Number })
+  readonly [PROPS.MIN_HEIGHT]: number
+
+  @Prop({ type: Number })
+  readonly [PROPS.MAX_HEIGHT]: number
+
   PROPS = PROPS
   EDITOR_TYPES_ENUM = EDITOR_TYPES_ENUM
   editor: Editor | null = null
@@ -130,6 +139,13 @@ export default class TiptapVuetify extends Vue {
 
   get toolbarActions () {
     return this[PROPS.EXTENSIONS].filter(i => i.renderIn)
+  }
+
+  get contentDynamicStyles () {
+    let dynamicStylesToReturn = {}
+    if (this[PROPS.MIN_HEIGHT]) Object.assign(dynamicStylesToReturn, { minHeight: `${this[PROPS.MIN_HEIGHT]}px` })
+    if (this[PROPS.MAX_HEIGHT]) Object.assign(dynamicStylesToReturn, { maxHeight: `${this[PROPS.MAX_HEIGHT]}px` })
+    return dynamicStylesToReturn
   }
 
   @Watch('value')

--- a/src/const.ts
+++ b/src/const.ts
@@ -16,7 +16,9 @@ export const PROPS = {
   PLACEHOLDER: 'placeholder' as const,
   CARD_PROPS: 'cardProps' as const,
   OUTPUT_FORMAT: 'outputFormat' as const,
-  TYPE: 'type' as const
+  TYPE: 'type' as const,
+  MIN_HEIGHT: 'minHeight' as const,
+  MAX_HEIGHT: 'maxHeight' as const
 }
 
 export enum EDITOR_TYPES_ENUM {


### PR DESCRIPTION
For example:

```
<tiptap-vuetify
      v-model="content"
      :extensions="extensions"
      placeholder="Write something …"
      :max-height="300"
    />
```

And the same goes for min-height.
The given unit transforms to pixels itself.