### PR TITLE
Remove pointer-events from links

### DIFF
--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -274,7 +274,7 @@ export default class TiptapVuetify extends Vue {
     transition: all 2s
     overflow: auto !important
     padding: 5px
-    
+
     a
       pointer-events: none
 

--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -274,6 +274,9 @@ export default class TiptapVuetify extends Vue {
     transition: all 2s
     overflow: auto !important
     padding: 5px
+    
+    a
+      pointer-events: none
 
     h1, h2, h3, h4
       margin: 10px 0 20px !important


### PR DESCRIPTION
It's cool to be able to add links to a selected text but it's almost impossible to remove the link since it will trigger the navigation when clicked. Providing a much better UX removing pointer events from `a` elements.