### PR TITLE
fix(i18n) useless warning about unsupported current language

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -46,9 +46,9 @@ export function getMsg (path: string, args?, lang: null | string = null): string
   let currentLang = lang || getCurrentLang()
 
   if (!dictionary[currentLang]) {
-    currentLang = defaultLanguage
-
     ConsoleLogger.warn(`The current language "${currentLang}" is not yet available. Using language "${defaultLanguage}" by default. Contribution to github is welcome.`)
+
+    currentLang = defaultLanguage
   }
 
   const dictionaryByLang = dictionary[currentLang]


### PR DESCRIPTION
In warning about unsupported language is current language rewritten to default and after that is message logged.
```javascript
Vuetify({locale: {current: 'XX'}})
```
now leads to:
```
tiptap-vuetify: The current language "en" is not yet available.
Using language "en" by default. Contribution to github is welcome.
```
but it should be:
```
tiptap-vuetify: The current language "XX" is not yet available.
Using language "en" by default. Contribution to github is welcome.
```