### PR TITLE
Update link input field label to "URL"

### DIFF
--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -106,7 +106,7 @@ export default {
       window: {
         title: 'Link control',
         form: {
-          hrefLabel: 'Href'
+          hrefLabel: 'URL'
         },
         buttons: {
           close: 'Close',


### PR DESCRIPTION
Update label for the English link input field to "URL" instead of "Href"