### PR TITLE
iconsGroup should be 'mdi' not 'md'

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Vue.use(TiptapVuetifyPlugin, {
   // the next line is important! You need to provide the Vuetify Object to this place.
   vuetify, // same as "vuetify: vuetify"
   // optional, default to 'md' (default vuetify icons before v2.0.0)
-  iconsGroup: 'md'
+  iconsGroup: 'mdi'
 })
 ```
 


### PR DESCRIPTION
If someone copies and pasts the code with 'md' the icons will not render, changing to 'mdi' fixes the problem.