### PR TITLE
feat: enable to style action button tooltip

### DIFF
--- a/src/extensions/actions/renders/btn/ExtensionActionRenderBtn.vue
+++ b/src/extensions/actions/renders/btn/ExtensionActionRenderBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip top>
+  <v-tooltip top :content-class="tiptap-vuetify-editor__action-tooltip">
     <!--:disabled="isButtonDisabled(commands, button)"-->
     <template #activator="{ on }">
       <!--TODO options.isActive сделать реактивным -->


### PR DESCRIPTION
Add a CSS class to editor action button tooltips. Poor man's solution to being able to customize action button tooltip.

Relates to https://github.com/iliyaZelenko/tiptap-vuetify/issues/151