### PR TITLE
Fix `minHeight` in contenteditable

### DIFF
--- a/src/components/TiptapVuetify.vue
+++ b/src/components/TiptapVuetify.vue
@@ -156,6 +156,19 @@ export default class TiptapVuetify extends Vue {
     }
   }
 
+  get minHeightInPixels () {
+    const minHeight = this[PROPS.MIN_HEIGHT]
+
+    if (minHeight) {
+      const isNumber = typeof minHeight === 'number'
+      const hasOnlyDigits = /^\d+$/.test(`${minHeight}`)
+
+      return isNumber || hasOnlyDigits ? `${minHeight}px` : minHeight
+    }
+
+    return null
+  }
+
   @Watch('disabled')
   onDisabledChange (val) {
     if (this.editor) this.editor.setOptions({ editable: !val })
@@ -248,7 +261,8 @@ export default class TiptapVuetify extends Vue {
       content: this[PROPS.VALUE],
       onUpdate: this.onUpdate.bind(this),
       onBlur: this.onBlur.bind(this),
-      onFocus: this.onFocus.bind(this)
+      onFocus: this.onFocus.bind(this),
+      onInit: this.onInit.bind(this)
     }))!
 
     this.$emit(EVENTS.INIT, {
@@ -278,6 +292,17 @@ export default class TiptapVuetify extends Vue {
 
   onFocus ({ event, view }) {
     this.$emit(EVENTS.FOCUS, event, view)
+  }
+
+  onInit ({ view }) {
+    const minHeightInPixels = this.minHeightInPixels
+
+    if (minHeightInPixels) {
+      const EDITOR_CONTENT_PADDING = '5px'
+      const CONTENTEDITABLE_MARGIN = '20px'
+
+      view.dom.style.minHeight = `calc(${minHeightInPixels} - (${CONTENTEDITABLE_MARGIN} * 2) - (${EDITOR_CONTENT_PADDING} * 2))`
+    }
   }
 
   beforeDestroy () {


### PR DESCRIPTION
Set `minHeight` in contenteditable allowing the user can focus on the editor by clicking on it. Before it, the contenteditable area was according to the text/content height so, if the user clicked outside it but inside the editor, the same was not being focused.

Issue #200 

### Before this fix

<img width="1813" alt="image" src="https://user-images.githubusercontent.com/2437673/168153064-58d843ce-9c69-4ce2-8ce8-dec3f7e09fa3.png">

> contenteditable are in red

### After this fix

<img width="1806" alt="image" src="https://user-images.githubusercontent.com/2437673/168154097-06ebd113-f217-4c9a-84c1-d6e78a9de140.png">

> contenteditable are in red



